### PR TITLE
Fix error handling and partitions in Mount-FslDisk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ Setup.ps1
 StartSOD.ps1
 build.ps1
 Startmount.ps1
+
+# Test results
+CodeCoverage.xml
+PesterTest.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Visual Studio Code project files
+.vscode
+
+# Development environment
 start.ps1
 notes.txt
 Setup.ps1

--- a/Functions/Private/Mount-FslDisk.ps1
+++ b/Functions/Private/Mount-FslDisk.ps1
@@ -49,9 +49,9 @@ function Mount-FslDisk {
             New-Item -Path $mountPath -ItemType Directory -ErrorAction Stop | Out-Null
         }
         catch {
-            Write-Error "Failed to create mounting directory $mountPath"
             # Cleanup
             $mountedDisk | Dismount-DiskImage -ErrorAction SilentlyContinue
+            Write-Error "Failed to create mounting directory $mountPath"
             return
         }
 
@@ -66,10 +66,10 @@ function Mount-FslDisk {
             Add-PartitionAccessPath @addPartitionAccessPathParams
         }
         catch {
-            Write-Error "Failed to create junction point to $mountPath"
             # Cleanup
             Remove-Item -Path $mountPath -Force -Recurse -ErrorAction SilentlyContinue
             $mountedDisk | Dismount-DiskImage -ErrorAction SilentlyContinue
+            Write-Error "Failed to create junction point to $mountPath"
             return
         }
 

--- a/Functions/Private/Shrink-OneDisk.ps1
+++ b/Functions/Private/Shrink-OneDisk.ps1
@@ -27,11 +27,6 @@ function Shrink-OneDisk {
         [Parameter(
             ValuefromPipelineByPropertyName = $true
         )]
-        [int]$PartitionNumber = 1,
-
-        [Parameter(
-            ValuefromPipelineByPropertyName = $true
-        )]
         [string]$LogFilePath = "$env:TEMP\FslShrinkDisk $(Get-Date -Format yyyy-MM-dd` HH-mm-ss).csv",
 
         [Parameter(
@@ -91,19 +86,19 @@ function Shrink-OneDisk {
 
         #Initial disk Mount
         try {
-            $mount = Mount-FslDisk -Path $Disk.FullName -PartitionNumber $PartitionNumber -PassThru -ErrorAction Stop
+            $mount = Mount-FslDisk -Path $Disk.FullName -PassThru -ErrorAction Stop
         }
         catch {
             Write-VhdOutput -DiskState 'DiskLocked'
             return
         }
 
-        $partInfo = Get-Partition -DiskNumber $mount.DiskNumber
+        $partInfo = Get-Partition -DiskNumber $mount.DiskNumber | Where-Object -Property 'Type' -EQ -Value 'Basic'
         Get-Volume -Partition $partInfo | Optimize-Volume
 
         #Grab partition information so we know what size to shrink the partition to and what to re-enlarge it to.  This helps optimise-vhd work at it's best
         try {
-            $partitionsize = Get-PartitionSupportedSize -DiskNumber $mount.DiskNumber -ErrorAction Stop
+            $partitionsize = Get-PartitionSupportedSize -InputObject $partInfo -ErrorAction Stop
             $sizeMax = $partitionsize.SizeMax
         }
         catch {
@@ -136,7 +131,7 @@ function Shrink-OneDisk {
         while ($i -le 5 -and $resize -eq $false){
 
             try {
-                Resize-Partition -DiskNumber $mount.DiskNumber -Size $targetSize -PartitionNumber $PartitionNumber -ErrorAction Stop
+                Resize-Partition -InputObject $partInfo -Size $targetSize -ErrorAction Stop
                 $resize = $true
             }
             catch {
@@ -207,7 +202,8 @@ function Shrink-OneDisk {
         #Now we need to reinflate the partition to its previous size
         try {
             $mount = Mount-FslDisk -Path $Disk.FullName -PassThru
-            Resize-Partition -DiskNumber $mount.DiskNumber -Size $sizeMax -PartitionNumber $PartitionNumber -ErrorAction Stop
+            $partInfo = Get-Partition -DiskNumber $mount.DiskNumber | Where-Object -Property 'Type' -EQ -Value 'Basic'
+            Resize-Partition -InputObject $partInfo -Size $sizeMax -ErrorAction Stop
             $paramWriteVhdOutput = @{
                 DiskState    = "Success"
                 FinalSizeGB  = $finalSizeGB

--- a/Functions/Private/Shrink-OneDisk.ps1
+++ b/Functions/Private/Shrink-OneDisk.ps1
@@ -91,7 +91,7 @@ function Shrink-OneDisk {
 
         #Initial disk Mount
         try {
-            $mount = Mount-FslDisk -Path $Disk.FullName -PassThru -ErrorAction Stop
+            $mount = Mount-FslDisk -Path $Disk.FullName -PartitionNumber $PartitionNumber -PassThru -ErrorAction Stop
         }
         catch {
             Write-VhdOutput -DiskState 'DiskLocked'

--- a/Invoke-FslShrinkDisk.ps1
+++ b/Invoke-FslShrinkDisk.ps1
@@ -14,7 +14,7 @@
         Powershell version 5.x and 7 and above are supported for this script. It needs to be run as administrator due to the requirement for mounting disks to the OS where the script is run.
         This tool is multi-threaded and will take advantage of multiple CPU cores on the machine from which you run the script.  It is not advised to run more than 2x the threads of your available cores on your machine.  You could also use the number of threads to throttle the load on your storage.
         Reducing the size of a virtual hard disk is a storage intensive activity.  The activity is more in file system metadata operations than pure IOPS, so make sure your storage controllers can handle the load.  The storage load occurs on the location where the disks are stored not on the machine where the script is run from.   I advise running the script out of hours if possible, to avoid impacting other users on the storage.
-        With the intention of reducing the storage load to the minimum possible, you can configure the script to only shrink the disks where you will see the most benefit.  You can delete disks which have not been accessed in x number of days previously (configurable).  Deletion of disks is not enabled by default.  By default the script will not run on any disk with less than 15% whitespace inside (configurable).  The script can optionally also not run on disks smaller than xGB (configurable) as it’s possible that even a large % of whitespace in small disks won’t result in a large capacity reclamation, but even shrinking a small amount of capacity will cause storage load.
+        With the intention of reducing the storage load to the minimum possible, you can configure the script to only shrink the disks where you will see the most benefit.  You can delete disks which have not been accessed in x number of days previously (configurable).  Deletion of disks is not enabled by default.  By default the script will not run on any disk with less than 5% whitespace inside (configurable).  The script can optionally also not run on disks smaller than xGB (configurable) as it’s possible that even a large % of whitespace in small disks won’t result in a large capacity reclamation, but even shrinking a small amount of capacity will cause storage load.
         The script will output a csv in the following format:
 
         "Name","DiskState","OriginalSizeGB","FinalSizeGB","SpaceSavedGB","FullName"
@@ -67,11 +67,8 @@
         .PARAMETER ThrottleLimit
         Specifies the number of disks that will be processed at a time. Further disks in the queue will wait till a previous disk has finished up to a maximum of the ThrottleLimit.  The  default value is 8.
 
-        .PARAMETER IgnoreLessThanGB
-        The disk size in GB under which the script will not process the file.
-
         .PARAMETER RatioFreeSpace
-        The minimum percentage of white space in the disk before processing will start as a decimal between 0 and 1 eg 0.2 is 20% 0.65 is 65%. The Default is 0.05 or 5%.  This means that if the available size reduction is less than 5%, then no action will be taken.  To try and shrink all files no matter how little the gain set this to 0.
+        The minimum percentage of white space in the disk before processing will start as a decimal between 0 and 1 eg 0.2 is 20% 0.65 is 65%. The Default is 0.05.  This means that if the available size reduction is less than 5%, then no action will be taken.  To try and shrink all files no matter how little the gain set this to 0.
 
         .INPUTS
         You can pipe the path into the command which is recognised by type, you can also pipe any parameter by name. It will also take the path positionally
@@ -786,9 +783,9 @@ function Mount-FslDisk {
             New-Item -Path $mountPath -ItemType Directory -ErrorAction Stop | Out-Null
         }
         catch {
-            Write-Error "Failed to create mounting directory $mountPath"
             # Cleanup
             $mountedDisk | Dismount-DiskImage -ErrorAction SilentlyContinue
+            Write-Error "Failed to create mounting directory $mountPath"
             return
         }
 
@@ -803,10 +800,10 @@ function Mount-FslDisk {
             Add-PartitionAccessPath @addPartitionAccessPathParams
         }
         catch {
-            Write-Error "Failed to create junction point to $mountPath"
             # Cleanup
             Remove-Item -Path $mountPath -Force -Recurse -ErrorAction SilentlyContinue
             $mountedDisk | Dismount-DiskImage -ErrorAction SilentlyContinue
+            Write-Error "Failed to create junction point to $mountPath"
             return
         }
 
@@ -1296,9 +1293,9 @@ function Mount-FslDisk {
             New-Item -Path $mountPath -ItemType Directory -ErrorAction Stop | Out-Null
         }
         catch {
-            Write-Error "Failed to create mounting directory $mountPath"
             # Cleanup
             $mountedDisk | Dismount-DiskImage -ErrorAction SilentlyContinue
+            Write-Error "Failed to create mounting directory $mountPath"
             return
         }
 
@@ -1313,10 +1310,10 @@ function Mount-FslDisk {
             Add-PartitionAccessPath @addPartitionAccessPathParams
         }
         catch {
-            Write-Error "Failed to create junction point to $mountPath"
             # Cleanup
             Remove-Item -Path $mountPath -Force -Recurse -ErrorAction SilentlyContinue
             $mountedDisk | Dismount-DiskImage -ErrorAction SilentlyContinue
+            Write-Error "Failed to create junction point to $mountPath"
             return
         }
 

--- a/Tests/Private/Mount-FslDisk.Tests.ps1
+++ b/Tests/Private/Mount-FslDisk.Tests.ps1
@@ -40,6 +40,16 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             PSTypeName        = 'Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/Storage/MSFT_DiskImage'
         }
     }
+    Mock -CommandName Get-Partition -MockWith {
+        [pscustomobject]@{
+            PartitionNumber = 1
+            Offset          = 0
+            Type            = 'Basic'
+            Size            = 31457280000
+            PSComputerName  = $null
+            PSTypeName      = 'Microsoft.Management.Infrastructure.CimInstance#ROOT/Microsoft/Windows/Storage/MSFT_Partition'
+        }
+    }
     Context "Input" {
 
         Mock -CommandName New-Item -MockWith { $null }

--- a/Tests/Private/Shrink-OneDisk.Tests.ps1
+++ b/Tests/Private/Shrink-OneDisk.Tests.ps1
@@ -49,7 +49,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Takes input via param" {
@@ -67,7 +66,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
                 IgnoreLessThanGB    = $IgnoreLessThanGB
                 LogFilePath         = $LogFilePath
                 RatioFreeSpace      = 0.2
-                Partition           = 1
             }
             $notdisk | Shrink-OneDisk @paramShrinkOneDisk -ErrorAction Stop | Should -BeNullOrEmpty
         }
@@ -79,7 +77,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
                 IgnoreLessThanGB    = $IgnoreLessThanGB
                 LogFilePath         = $LogFilePath
                 RatioFreeSpace      = 0.2
-                Partition           = 1
             }
             $pipeShrinkOneDisk | Shrink-OneDisk -ErrorAction Stop | Should -BeNullOrEmpty
         }
@@ -101,7 +98,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
 
@@ -118,7 +114,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output when not disk" {
@@ -134,7 +129,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = 5
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output disk is too small" {
@@ -152,7 +146,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output when disk is Locked" {
@@ -173,7 +166,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output when No Partition" -Skip {
@@ -191,7 +183,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output when Shrink Partition Fail" -Skip {
@@ -207,7 +198,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.5
-            Partition           = 1
         }
 
         It "Gives right output when No Partition Space" -Skip {
@@ -226,7 +216,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output when Shrink Disk Fail" -Skip {
@@ -245,7 +234,6 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
             IgnoreLessThanGB    = $IgnoreLessThanGB
             LogFilePath         = $LogFilePath
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output when estore Partition size Fail" -Skip {
@@ -260,9 +248,7 @@ Describe "Describing $($sut.Trimend('.ps1'))" {
         $paramShrinkOneDisk = @{
             DeleteOlderThanDays = $DeleteOlderThanDays
             IgnoreLessThanGB    = $IgnoreLessThanGB
-
             RatioFreeSpace      = 0.2
-            Partition           = 1
         }
 
         It "Gives right output when Shink Successful" -Skip {


### PR DESCRIPTION
* Move Write-Error to end of cleanup block during error handling
* Pass through the partition number from the Shrink-OneDisk command to Mount-FslDisk