### PR TITLE
Fixed issue where the script would fail when 'Optimize Drives' service is not running or disabled.

### DIFF
--- a/Invoke-FslShrinkDisk.ps1
+++ b/Invoke-FslShrinkDisk.ps1
@@ -452,8 +452,7 @@ function Invoke-Parallel {
                             $log.status = "CompletedWithErrors"
                             Write-Verbose ($log | ConvertTo-Csv -Delimiter ";" -NoTypeInformation)[1]
                             foreach ($ErrorRecord in $runspace.powershell.Streams.Error) {
-                                #Write-Error -ErrorRecord $ErrorRecord
-                                $PSCmdlet.ThrowTerminatingError($ErrorRecord)
+                                Write-Error -ErrorRecord $ErrorRecord
                             }
                         }
                         else {


### PR DESCRIPTION
This is a great piece of work.  I found this issue when it failed to run.  The error was ambiguous due to it getting created from inside the runspace.  I also realized the Export-CSV cmdlet was missed the -NoTypeInformation parameter which provides cleaner output.  Lastly, while the CSV output is nice, I added the import of the log file to the end and output it in a table so you don't have to go hunt for the results.

Happy to discuss these changes and hope it helps.

//Jason